### PR TITLE
Update markdown #tag matching

### DIFF
--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -29,6 +29,16 @@ export default class Markdown extends React.Component {
         }
 
         return input
+        // hashtags #tagname
+            .replace(/(?!\B[\w+-\/]+\b)\B#(\b[\w+-\/]+\b)/g, function(fullTag, tagName) {
+                if (owner && name) {
+                    return `<a href='#/projects/${owner}/${name}/talk/search?query=${tagName}'>${fullTag}</a>`;
+                }
+                else {
+                    return `<a href='#/talk/search?query=${tagName}'>${fullTag}</a>`;
+                }
+            })
+
         // subjects in a specific project : @owner-slug/project-slug^subject_id
         // \b[\w-]+\b is hyphen boundary for slugs
             .replace(/@(\b[\w-]+\b)\/(\b[\w-]+\b)\^([0-9]+)/g, "<a href='#/projects/$1/$2/talk/subjects/$3'>$1/$2 - Subject $3</a>")
@@ -45,15 +55,6 @@ export default class Markdown extends React.Component {
         // user mentions : @username
             .replace(/\B@(\b[\w-]+\b)/g, "<a href='#/users/$1'>@$1</a>")
 
-        // hashtags #tagname
-            .replace(/(?!\B.*\/)\B#(\b[\w+-\/]+\b)/g, function(fullTag, tagName) {
-                if (owner && name) {
-                    return `<a href='#/projects/${owner}/${name}/talk/search?query=${tagName}'>${fullTag}</a>`;
-                }
-                else {
-                    return `<a href='#/talk/search?query=${tagName}'>${fullTag}</a>`;
-                }
-            });
     }
 
     emojify(input) {

--- a/test/components/markdown-editor-test.js
+++ b/test/components/markdown-editor-test.js
@@ -171,7 +171,7 @@ describe('MarkdownEditor', () => {
         });
 
         it("should render a markdown preview from the value property", () => {
-            editor = addons.TestUtils.renderIntoDocument(<MarkdownEditor value="##blah blah"/>);
+            editor = addons.TestUtils.renderIntoDocument(<MarkdownEditor value="## blah blah"/>);
             let markdown = addons.TestUtils.findRenderedDOMComponentWithClass(editor, "markdown-editor-preview")
             expect(markdown.props.dangerouslySetInnerHTML.__html).to.match(/blah blah/);
         });

--- a/test/components/markdown-test.js
+++ b/test/components/markdown-test.js
@@ -35,6 +35,12 @@ describe('Markdown', () => {
             expect(tagLink).to.equal("<a href='#/talk/search?query=test'>#test</a>");
         });
 
+        it('replaces #hashtags inside of html without conflicting with urls', () => {
+            let htmlTagLink = markdown.replaceSymbols(`<p>#good \n https://www.zooniverse.org/#/talk/17/1403?page=1&comment=3063</p>`);
+
+            expect(htmlTagLink).to.equal(`<p><a href=\'#/talk/search?query=good\'>#good</a> \n https://www.zooniverse.org/#/talk/17/1403?page=1&comment=3063</p>`)
+        })
+
         it('replaces ^subject mentions with subject links', () =>{
             markdown.getParams = () => {
                 return {


### PR DESCRIPTION
- Improves boundary case when rendered in the context of a URL or HTML