### PR TITLE
Remove replaceSymbols method, add transform prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Markdown viewer and editor for the Zooniverse",
   "main": "src/index.js",
   "scripts": {
+    "start": "gulp watch",
     "test": "gulp test",
     "test-sauce": "zuul -- test/**/*.js"
   },

--- a/src/components/markdown-editor.js
+++ b/src/components/markdown-editor.js
@@ -111,7 +111,7 @@ export default class MarkdownEditor extends React.Component {
                     <div className="editor-area">
                         <textarea ref="textarea" className="markdown-editor-input" name={this.props.name} placeholder={this.props.placeholder} value={this.props.value} rows={this.props.rows} cols={this.props.cols} onChange={this.onInputChange.bind(this)} />
 
-                        <Markdown className="markdown-editor-preview">{this.props.value}</Markdown>
+                        <Markdown className="markdown-editor-preview" transform={this.props.transform}>{this.props.value}</Markdown>
                     </div>
                 </div>
         );
@@ -186,6 +186,7 @@ MarkdownEditor.defaultProps = {
     value: '',
     placeholder: '',
     rows: 5,
+    transform: arg => arg,
     onChange: NOOP,
     previewing: null,
     onHelp: NOOP
@@ -194,4 +195,3 @@ MarkdownEditor.defaultProps = {
 MarkdownEditor.initialState = {
     previewing: false
 };
-

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -2,8 +2,6 @@ import React from "react";
 import MarkdownIt from "markdown-it";
 import MarkdownItContainer from "markdown-it-container";
 import twemoji from 'twemoji';
-import {State} from 'react-router';
-import reactMixin from 'react-mixin';
 
 const markdownIt = new MarkdownIt({linkify: true, breaks: true})
           .use(require('markdown-it-emoji'))
@@ -16,45 +14,6 @@ const markdownIt = new MarkdownIt({linkify: true, breaks: true})
 export default class Markdown extends React.Component {
     get displayName() {
         return 'Markdown';
-    }
-
-    replaceSymbols(input) {
-        // Catch getParams in case we're in a non-routed context like an alert
-        var owner, name;
-        try {
-            ({owner, name} = this.getParams());
-        } catch (_) {
-            owner = null;
-            name = null;
-        }
-
-        return input
-        // hashtags #tagname
-            .replace(/(?!\B[\w+-\/]+\b)\B#(\b[\w+-\/]+\b)/g, function(fullTag, tagName) {
-                if (owner && name) {
-                    return `<a href='#/projects/${owner}/${name}/talk/search?query=${tagName}'>${fullTag}</a>`;
-                }
-                else {
-                    return `<a href='#/talk/search?query=${tagName}'>${fullTag}</a>`;
-                }
-            })
-
-        // subjects in a specific project : @owner-slug/project-slug^subject_id
-        // \b[\w-]+\b is hyphen boundary for slugs
-            .replace(/@(\b[\w-]+\b)\/(\b[\w-]+\b)\^([0-9]+)/g, "<a href='#/projects/$1/$2/talk/subjects/$3'>$1/$2 - Subject $3</a>")
-
-            .replace(/\^([0-9]+)/g, function(_, subjectID) {
-                if (owner && name) {
-                    return `<a href='#/projects/${owner}/${name}/talk/subjects/${subjectID}'>${owner}/${name} - Subject ${subjectID}</a>`;
-                }
-                else {
-                    return subjectID;
-                }
-            })
-
-        // user mentions : @username
-            .replace(/\B@(\b[\w-]+\b)/g, "<a href='#/users/$1'>@$1</a>")
-
     }
 
     emojify(input) {
@@ -72,7 +31,7 @@ export default class Markdown extends React.Component {
 
     getHtml() {
         try {
-            return this.replaceSymbols(this.emojify(this.markdownify(this.props.children || this.props.content)));
+            return this.props.transform(this.emojify(this.markdownify(this.props.children || this.props.content)));
         } catch (e) {
             return this.props.children || this.props.content;
         }
@@ -92,7 +51,6 @@ Markdown.defaultProps = {
     tag: 'div',
     content: '',
     inline: false,
+    transform: arg => arg,
     className: ''
 }
-
-reactMixin.onClass(Markdown, State);


### PR DESCRIPTION
This removes the `replaceSymbols` method and moves its behavior into a `transform` prop. That way we can pass in the current router so we can generate links in the proper context.

Once this is merged, let's bump the version and publish, and then I'll update zooniverse/Panoptes-Front-End#1408, which closes #8.