### PR TITLE
Project as prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Markdown viewer and editor for the Zooniverse",
   "main": "src/index.js",
   "scripts": {
+    "start": "gulp watch",
     "test": "gulp test",
     "test-sauce": "zuul -- test/**/*.js"
   },

--- a/src/components/markdown-editor.js
+++ b/src/components/markdown-editor.js
@@ -111,7 +111,7 @@ export default class MarkdownEditor extends React.Component {
                     <div className="editor-area">
                         <textarea ref="textarea" className="markdown-editor-input" name={this.props.name} placeholder={this.props.placeholder} value={this.props.value} rows={this.props.rows} cols={this.props.cols} onChange={this.onInputChange.bind(this)} />
 
-                        <Markdown className="markdown-editor-preview">{this.props.value}</Markdown>
+                        <Markdown className="markdown-editor-preview" transform={this.props.transform}>{this.props.value}</Markdown>
                     </div>
                 </div>
         );
@@ -186,6 +186,7 @@ MarkdownEditor.defaultProps = {
     value: '',
     placeholder: '',
     rows: 5,
+    transform: arg => arg,
     onChange: NOOP,
     previewing: null,
     onHelp: NOOP
@@ -194,4 +195,3 @@ MarkdownEditor.defaultProps = {
 MarkdownEditor.initialState = {
     previewing: false
 };
-

--- a/src/components/markdown-editor.js
+++ b/src/components/markdown-editor.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Markdown from './markdown';
 import m from '../lib/markdown-insert';
+import replaceSymbols from '../lib/default-transformer';
 
 var NOOP = Function.prototype;
 
@@ -111,7 +112,7 @@ export default class MarkdownEditor extends React.Component {
                     <div className="editor-area">
                         <textarea ref="textarea" className="markdown-editor-input" name={this.props.name} placeholder={this.props.placeholder} value={this.props.value} rows={this.props.rows} cols={this.props.cols} onChange={this.onInputChange.bind(this)} />
 
-                        <Markdown className="markdown-editor-preview" transform={this.props.transform}>{this.props.value}</Markdown>
+                        <Markdown className="markdown-editor-preview" project={this.props.project} baseURI={this.props.baseURI} transform={this.props.transform}>{this.props.value}</Markdown>
                     </div>
                 </div>
         );
@@ -186,10 +187,12 @@ MarkdownEditor.defaultProps = {
     value: '',
     placeholder: '',
     rows: 5,
-    transform: arg => arg,
+    transform: replaceSymbols,
     onChange: NOOP,
     previewing: null,
-    onHelp: NOOP
+    onHelp: NOOP,
+    project: null,
+    baseURI: null
 };
 
 MarkdownEditor.initialState = {

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -2,8 +2,6 @@ import React from "react";
 import MarkdownIt from "markdown-it";
 import MarkdownItContainer from "markdown-it-container";
 import twemoji from 'twemoji';
-import {State} from 'react-router';
-import reactMixin from 'react-mixin';
 
 const markdownIt = new MarkdownIt({linkify: true, breaks: true})
           .use(require('markdown-it-emoji'))
@@ -16,45 +14,6 @@ const markdownIt = new MarkdownIt({linkify: true, breaks: true})
 export default class Markdown extends React.Component {
     get displayName() {
         return 'Markdown';
-    }
-
-    replaceSymbols(input) {
-        // Catch getParams in case we're in a non-routed context like an alert
-        var owner, name;
-        try {
-            ({owner, name} = this.getParams());
-        } catch (_) {
-            owner = null;
-            name = null;
-        }
-
-        return input
-        // hashtags #tagname
-            .replace(/(?!\B[\w+-\/]+\b)\B#(\b[\w+-\/]+\b)/g, function(fullTag, tagName) {
-                if (owner && name) {
-                    return `<a href='#/projects/${owner}/${name}/talk/search?query=${tagName}'>${fullTag}</a>`;
-                }
-                else {
-                    return `<a href='#/talk/search?query=${tagName}'>${fullTag}</a>`;
-                }
-            })
-
-        // subjects in a specific project : @owner-slug/project-slug^subject_id
-        // \b[\w-]+\b is hyphen boundary for slugs
-            .replace(/@(\b[\w-]+\b)\/(\b[\w-]+\b)\^([0-9]+)/g, "<a href='#/projects/$1/$2/talk/subjects/$3'>$1/$2 - Subject $3</a>")
-
-            .replace(/\^([0-9]+)/g, function(_, subjectID) {
-                if (owner && name) {
-                    return `<a href='#/projects/${owner}/${name}/talk/subjects/${subjectID}'>${owner}/${name} - Subject ${subjectID}</a>`;
-                }
-                else {
-                    return subjectID;
-                }
-            })
-
-        // user mentions : @username
-            .replace(/\B@(\b[\w-]+\b)/g, "<a href='#/users/$1'>@$1</a>")
-
     }
 
     emojify(input) {
@@ -72,7 +31,7 @@ export default class Markdown extends React.Component {
 
     getHtml() {
         try {
-            return this.replaceSymbols(this.emojify(this.markdownify(this.props.children || this.props.content)));
+            return this.props.transform(this.emojify(this.markdownify(this.props.children || this.props.content)));
         } catch (e) {
             return this.props.children || this.props.content;
         }
@@ -92,7 +51,6 @@ Markdown.defaultProps = {
     tag: 'div',
     content: '',
     inline: false,
+    transform: arg => arg,
     className: ''
 }
-
-reactMixin.onClass(Markdown, State);

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -2,6 +2,7 @@ import React from "react";
 import MarkdownIt from "markdown-it";
 import MarkdownItContainer from "markdown-it-container";
 import twemoji from 'twemoji';
+import replaceSymbols from '../lib/default-transformer';
 
 const markdownIt = new MarkdownIt({linkify: true, breaks: true})
           .use(require('markdown-it-emoji'))
@@ -31,14 +32,21 @@ export default class Markdown extends React.Component {
 
     getHtml() {
         try {
-            return this.props.transform(this.emojify(this.markdownify(this.props.children || this.props.content)));
+            let html = this.emojify(this.markdownify(this.props.children || this.props.content));
+            if (typeof this.props.transform === 'function') {
+                let {project, baseURI} = this.props;
+                return this.props.transform(html, {project, baseURI});
+            }
+            else {
+                return html;
+            }
         } catch (e) {
             return this.props.children || this.props.content;
         }
     }
 
     render() {
-        var html = this.getHtml()
+        var html = this.getHtml();
 
         return React.createElement(this.props.tag,{
             className: `markdown ${this.props.className}`,
@@ -51,6 +59,8 @@ Markdown.defaultProps = {
     tag: 'div',
     content: '',
     inline: false,
-    transform: arg => arg,
+    transform: replaceSymbols,
+    project: null,
+    baseURI: null,
     className: ''
 }

--- a/src/lib/default-transformer.js
+++ b/src/lib/default-transformer.js
@@ -1,0 +1,37 @@
+export default function(input, {project, baseURI}) {
+    let owner, name;
+    if (project) {
+        [owner, name] = project.slug.split("/");
+    }
+    if (!baseURI) {
+        baseURI = "#";
+    }
+
+    return input
+    // hashtags #tagname
+        .replace(/(?!\B[\w+-\/]+\b)\B#(\b[\w+-\/]+\b)/g, function(fullTag, tagName) {
+            if (owner && name) {
+                return `<a href="${baseURI}/projects/${owner}/${name}/talk/search?query=${tagName}">${fullTag}</a>`;
+            }
+            else {
+                return `<a href="${baseURI}/talk/search?query=${tagName}">${fullTag}</a>`;
+            }
+        })
+
+    // subjects in a specific project : @owner-slug/project-slug^subject_id
+    // \b[\w-]+\b is hyphen boundary for slugs
+        .replace(/@(\b[\w-]+\b)\/(\b[\w-]+\b)\^([0-9]+)/g, `<a href="${baseURI}/projects/$1/$2/talk/subjects/$3">$1/$2 - Subject $3</a>`)
+
+        .replace(/\^([0-9]+)/g, function(_, subjectID) {
+            if (owner && name) {
+                return `<a href="${baseURI}/projects/${owner}/${name}/talk/subjects/${subjectID}">${owner}/${name} - Subject ${subjectID}</a>`;
+            }
+            else {
+                return subjectID;
+            }
+        })
+
+    // user mentions : @username
+        .replace(/\B@(\b[\w-]+\b)/g, `<a href="${baseURI}/users/$1">@$1</a>`);
+
+}

--- a/test/components/markdown-test.js
+++ b/test/components/markdown-test.js
@@ -25,6 +25,8 @@ describe('Markdown', () => {
             tag: 'div',
             content: '',
             inline: false,
+            baseURI: null,
+            project: null,
             transform: Markdown.defaultProps.transform,
             className: ''
         });
@@ -41,21 +43,21 @@ describe('Markdown', () => {
         var md = TestUtils.renderIntoDocument(React.createElement(Markdown, { className: 'MyComponent'}, 'Test text'));
 
         it('returns the formatted html', () => {
-            let html = md.getHtml()
-            expect(html).to.equal('<p>Test text</p>\n')
-        })
+            let html = md.getHtml();
+            expect(html).to.equal('<p>Test text</p>\n');
+        });
 
         it('renders bare child content on error', () => {
             md.props.transform = () => {
-                throw new Error("fail")
-            }
-            let html = md.getHtml()
-            expect(html).to.equal('Test text')
-        })
-    })
+                throw new Error("fail");
+            };
+            let html = md.getHtml();
+            expect(html).to.equal('Test text');
+        });
+    });
 
     describe('#render', () => {
-        var editor, md
+        var editor, md;
         before(() => {
             editor = React.createElement(Markdown, {
               className: 'MyComponent',
@@ -65,7 +67,7 @@ describe('Markdown', () => {
               }
             }, 'Test children foo');
             md = TestUtils.renderIntoDocument(editor);
-        })
+        });
 
         it('renders', () => {
             var markdownDiv = TestUtils.findRenderedDOMComponentWithTag(md, 'div');
@@ -73,17 +75,17 @@ describe('Markdown', () => {
         });
 
         it('calls getHtml in render', () => {
-            let getHtmlSpy = spy.on(md, 'getHtml')
-            md.render()
-            expect(getHtmlSpy).to.have.been.called()
+            let getHtmlSpy = spy.on(md, 'getHtml');
+            md.render();
+            expect(getHtmlSpy).to.have.been.called();
         });
 
         it('returns a react component, with customizable tag', () =>{
-            var editor = React.createElement(Markdown, {className: 'PMarkdown', tag: 'p'}, 'Test p tag')
+            var editor = React.createElement(Markdown, {className: 'PMarkdown', tag: 'p'}, 'Test p tag');
             var md = TestUtils.renderIntoDocument(editor);
 
-            let renderValue = md.render()
-            expect(renderValue.type).to.equal('p')
-        })
+            let renderValue = md.render();
+            expect(renderValue.type).to.equal('p');
+        });
     });
 });

--- a/test/lib/default-transformer-test.js
+++ b/test/lib/default-transformer-test.js
@@ -1,0 +1,44 @@
+import replaceSymbols from '../../src/lib/default-transformer';
+import chai from 'chai';
+import spies from 'chai-spies';
+
+chai.use(spies);
+
+let {expect, spy} = chai;
+
+describe('default-transformer', () => {
+    var project, baseURI;
+    beforeEach(() => {
+        project = null;
+        baseURI = null;
+    });
+
+    it('replaces #hashtags with hashtag links', () => {
+        var tagLink = replaceSymbols('#test', {project, baseURI});
+        expect(tagLink).to.equal('<a href="#/talk/search?query=test">#test</a>');
+    });
+
+    it('replaces #hashtags inside of html without conflicting with urls', () => {
+        let html = `<p>#good \n https://www.zooniverse.org/#/talk/17/1403?page=1&comment=3063</p>`;
+        let htmlTagLink = replaceSymbols(html, {project, baseURI});
+
+        expect(htmlTagLink).to.equal(`<p><a href="#/talk/search?query=good">#good</a> \n https://www.zooniverse.org/#/talk/17/1403?page=1&comment=3063</p>`);
+    });
+
+    it('replaces ^subject mentions with subject links', () =>{
+        project = { slug: "test/project" };
+        var subjectLink = replaceSymbols('^123456', {project, baseURI});;
+        expect(subjectLink).to.equal('<a href="#/projects/test/project/talk/subjects/123456">test/project - Subject 123456</a>');
+    });
+
+    it('does not format subject Ids when not in a routed context', () =>{
+        var subjectLink = replaceSymbols('^123456', {project, baseURI});
+        expect(subjectLink).to.equal("123456");
+    });
+
+    it('replaces @ownerslug/project-slug^subject_id mentions with links', () => {
+        var projectSubjectLink = replaceSymbols('@owner/project-d^123456', {project, baseURI});
+
+        expect(projectSubjectLink).to.equal('<a href="#/projects/owner/project-d/talk/subjects/123456">owner/project-d - Subject 123456</a>');
+    });
+});


### PR DESCRIPTION
This uses the old `replaceSymbols` function as the default `props.transform` for the markdown-viewer. It also add a baseURI prop and a project prop to the viewer that are used to generate the links from the transform function. 