### PR TITLE
Add markdownit extension to open links in new tabs

### DIFF
--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -9,6 +9,7 @@ const markdownIt = new MarkdownIt({linkify: true, breaks: true})
           .use(require('markdown-it-sub'))
           .use(require('markdown-it-sup'))
           .use(require('markdown-it-footnote'))
+          .use(require('../lib/links-in-new-tabs'))
           .use(MarkdownItContainer, 'partners')
           .use(MarkdownItContainer, 'attribution');
 

--- a/src/lib/links-in-new-tabs.js
+++ b/src/lib/links-in-new-tabs.js
@@ -1,0 +1,35 @@
+/* 
+ markdown-it-links-in-new-tabs.js
+ opens links in a new tab if prefixed with +tab+
+ accepts options of {prefix: 'your-custom-prefix'}
+ 'prefix' is the string to use before links for links to open in new tab
+ */ 
+
+export default function(md, opts) {
+    // Remember old renderer, if overridden, or proxy to default renderer
+    var defaultRender = md.renderer.rules.link_open || function(tokens, idx, options, env, self) {
+        return self.renderToken(tokens, idx, options);
+    };
+
+    const prefix = (opts && opts.prefix) ? opts.prefix : '+tab+';
+
+    md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+        var hrefIndex = tokens[idx].attrIndex('href');
+        var href = tokens[idx].attrs[hrefIndex][1];
+
+        if (prefix === href.slice(0, prefix.length)) {
+            // trim prefix if href starts with prefix
+            tokens[idx].attrs[hrefIndex][1] = href.slice(prefix.length, href.length);
+            var aIndex = tokens[idx].attrIndex('target');
+
+            if (aIndex < 0) {
+                tokens[idx].attrPush(['target', '_blank']); // add new attribute
+            } else {
+                tokens[idx].attrs[aIndex][1] = '_blank';    // replace value of existing attr
+            }
+        }
+
+        // pass token to default renderer
+        return defaultRender(tokens, idx, options, env, self);
+    };
+}

--- a/test/components/markdown-test.js
+++ b/test/components/markdown-test.js
@@ -37,6 +37,11 @@ describe('Markdown', () => {
             var md = markdown.markdownify('# test header');
             expect(md).to.equal('<h1>test header</h1>\n');
         });
+
+        it('opens links in a new tab when prefixed by +tab+', () => {
+            var md = markdown.markdownify('[A link](+tab+http://www.google.com)');
+            expect(md).to.equal('<p><a href="http://www.google.com" target="_blank">A link</a></p>\n')
+        });
     });
 
     describe('#getHtml', () =>{

--- a/test/lib/links-in-new-tabs-test.js
+++ b/test/lib/links-in-new-tabs-test.js
@@ -1,0 +1,34 @@
+import linksInNewTabs from '../../src/lib/links-in-new-tabs';
+import MarkdownIt from 'markdown-it'
+import chai from 'chai';
+import spies from 'chai-spies';
+chai.use(spies);
+let {expect, spy} = chai;
+
+describe('links-in-new-tabs', () => {
+    var mdIt;
+
+    beforeEach(() => {
+        mdIt = new MarkdownIt({linkify: true, breaks: true})
+            .use(linksInNewTabs)
+    });
+
+    it('opens links prefixed with +tab+ in a _blank target by default', () => {
+        const md = mdIt.renderInline('[Test](+tab+http://www.example.com)');
+        expect(md).to.equal('<a href="http://www.example.com" target="_blank">Test</a>');
+    });
+
+    it('renders normal links without a new tab prefix', () => {
+        const md = mdIt.renderInline('[Test](http://www.example.com)');
+        expect(md).to.equal('<a href="http://www.example.com">Test</a>');
+    });
+
+    it('accepts a customizable prefix', () => {
+        mdIt = new MarkdownIt({linkify: true, breaks: true})
+            .use(linksInNewTabs, {prefix: '=newtab='})
+
+        const md = mdIt.renderInline('[Test](=newtab=http://www.example.com)');
+        expect(md).to.equal('<a href="http://www.example.com" target="_blank">Test</a>');
+    });
+});
+


### PR DESCRIPTION
- Links prefixed with `+tab+` or whatever the prefix is set to will have
  the `target="_blank"` attribute added to them
- Open to suggestions on the default prefix, otherwise I went with `+tab+` since it seems somewhat intuitive
- For https://github.com/zooniverse/Panoptes-Front-End/issues/946