### PR TITLE
Update tests for prefix change

### DIFF
--- a/src/lib/default-transformer.js
+++ b/src/lib/default-transformer.js
@@ -32,6 +32,6 @@ export default function(input, {project, baseURI}) {
         })
 
     // user mentions : @username
-        .replace(/\B@(\b[\w-]+\b)/g, `<a href="${baseURI}/users/$1">@$1</a>`);
+        .replace(/\B@(\b[\w-.]+\b)/g, `<a href="${baseURI}/users/$1">@$1</a>`);
 
 }

--- a/test/lib/default-transformer-test.js
+++ b/test/lib/default-transformer-test.js
@@ -15,20 +15,20 @@ describe('default-transformer', () => {
 
     it('replaces #hashtags with hashtag links', () => {
         var tagLink = replaceSymbols('#test', {project, baseURI});
-        expect(tagLink).to.equal('<a href="#/talk/search?query=test">#test</a>');
+        expect(tagLink).to.equal('<a href="/talk/search?query=test">#test</a>');
     });
 
     it('replaces #hashtags inside of html without conflicting with urls', () => {
-        let html = `<p>#good \n https://www.zooniverse.org/#/talk/17/1403?page=1&comment=3063</p>`;
+        let html = `<p>#good \n https://www.zooniverse.org/talk/17/1403?page=1&comment=3063</p>`;
         let htmlTagLink = replaceSymbols(html, {project, baseURI});
 
-        expect(htmlTagLink).to.equal(`<p><a href="#/talk/search?query=good">#good</a> \n https://www.zooniverse.org/#/talk/17/1403?page=1&comment=3063</p>`);
+        expect(htmlTagLink).to.equal(`<p><a href="/talk/search?query=good">#good</a> \n https://www.zooniverse.org/talk/17/1403?page=1&comment=3063</p>`);
     });
 
     it('replaces ^S<subject_id> mentions with subject links', () =>{
         project = { slug: "test/project" };
         var subjectLink = replaceSymbols('^S123456', {project, baseURI});;
-        expect(subjectLink).to.equal('<a href="#/projects/test/project/talk/subjects/123456">test/project - Subject 123456</a>');
+        expect(subjectLink).to.equal('<a href="/projects/test/project/talk/subjects/123456">test/project - Subject 123456</a>');
     });
 
     it('does not format subject Ids when not in a routed context', () =>{
@@ -39,6 +39,6 @@ describe('default-transformer', () => {
     it('replaces @ownerslug/project-slug^S<subject_id> mentions with links', () => {
         var projectSubjectLink = replaceSymbols('@owner/project-d^S123456', {project, baseURI});
 
-        expect(projectSubjectLink).to.equal('<a href="#/projects/owner/project-d/talk/subjects/123456">owner/project-d - Subject 123456</a>');
+        expect(projectSubjectLink).to.equal('<a href="/projects/owner/project-d/talk/subjects/123456">owner/project-d - Subject 123456</a>');
     });
 });

--- a/test/lib/default-transformer-test.js
+++ b/test/lib/default-transformer-test.js
@@ -36,6 +36,16 @@ describe('default-transformer', () => {
         expect(subjectLink).to.equal("123456");
     });
 
+    it('replaces @username mentions with user links', () => {
+        const userLink = replaceSymbols('@testuser', {project, baseURI});
+        expect(userLink).to.equal('<a href="/users/testuser">@testuser</a>');
+    });
+
+    it('replaces @user.name mentions with user links', () => {
+        const userLink = replaceSymbols('@test.user', {project, baseURI});
+        expect(userLink).to.equal('<a href="/users/test.user">@test.user</a>');
+    });
+
     it('replaces @ownerslug/project-slug^S<subject_id> mentions with links', () => {
         var projectSubjectLink = replaceSymbols('@owner/project-d^S123456', {project, baseURI});
 


### PR DESCRIPTION
- Noticed that 3b6c67e066e9c999389eb2b7062961b56ed2be07 broke some of the tests.
- Also adds period delimiter for @user.name mentions
