### PR TITLE
Shorten subject link display, add titles

### DIFF
--- a/src/lib/default-transformer.js
+++ b/src/lib/default-transformer.js
@@ -22,11 +22,11 @@ export default function(input, {project, baseURI}) {
 
     // subjects in a specific project : @owner-slug/project-slug^Ssubject_id
     // \b[\w-]+\b is hyphen boundary for slugs
-        .replace(/@(\b[\w-]+\b)\/(\b[\w-]+\b)\^S([0-9]+)/g, `<a href="${baseURI}/projects/$1/$2/talk/subjects/$3">$1/$2 - Subject $3</a>`)
+        .replace(/@(\b[\w-]+\b)\/(\b[\w-]+\b)\^S([0-9]+)/g, `<a href="${baseURI}/projects/$1/$2/talk/subjects/$3" title="$1/$2 - Subject $3">Subject $3</a>`)
 
         .replace(/\^S([0-9]+)/g, function(_, subjectID) {
             if (owner && name) {
-                return `<a href="${baseURI}/projects/${owner}/${name}/talk/subjects/${subjectID}">${owner}/${name} - Subject ${subjectID}</a>`;
+                return `<a href="${baseURI}/projects/${owner}/${name}/talk/subjects/${subjectID}" title="${owner}/${name} - Subject ${subjectID}" >Subject ${subjectID}</a>`;
             }
             else {
                 return subjectID;

--- a/test/lib/default-transformer-test.js
+++ b/test/lib/default-transformer-test.js
@@ -28,7 +28,7 @@ describe('default-transformer', () => {
     it('replaces ^S<subject_id> mentions with subject links', () =>{
         project = { slug: "test/project" };
         var subjectLink = replaceSymbols('^S123456', {project, baseURI});;
-        expect(subjectLink).to.equal('<a href="/projects/test/project/talk/subjects/123456">test/project - Subject 123456</a>');
+        expect(subjectLink).to.equal('<a href="/projects/test/project/talk/subjects/123456" title="test/project - Subject 123456" >Subject 123456</a>');
     });
 
     it('does not format subject Ids when not in a routed context', () =>{
@@ -54,6 +54,6 @@ describe('default-transformer', () => {
     it('replaces @ownerslug/project-slug^S<subject_id> mentions with links', () => {
         var projectSubjectLink = replaceSymbols('@owner/project-d^S123456', {project, baseURI});
 
-        expect(projectSubjectLink).to.equal('<a href="/projects/owner/project-d/talk/subjects/123456">owner/project-d - Subject 123456</a>');
+        expect(projectSubjectLink).to.equal('<a href="/projects/owner/project-d/talk/subjects/123456" title="owner/project-d - Subject 123456">Subject 123456</a>');
     });
 });


### PR DESCRIPTION
- Shortens subject link display to just Subject - <id>
- Preserves the longer form via the title attribute
- For https://github.com/zooniverse/Panoptes-Front-End/issues/1482