### PR TITLE
Replace symbol generation with markdown

### DIFF
--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -34,13 +34,13 @@ export default class Markdown extends React.Component {
 
     getHtml() {
         try {
-            let html = this.emojify(this.markdownify(this.props.children || this.props.content));
+            let {project, baseURI} = this.props;
+
             if (typeof this.props.transform === 'function') {
-                let {project, baseURI} = this.props;
-                return this.props.transform(html, {project, baseURI});
+                return this.emojify(this.markdownify(this.props.transform(this.props.children || this.props.content, {project, baseURI})));
             }
             else {
-                return html;
+                return this.emojify(this.markdownify(this.props.children || this.props.content));
             }
         } catch (e) {
             return this.props.children || this.props.content;

--- a/src/lib/default-transformer.js
+++ b/src/lib/default-transformer.js
@@ -13,20 +13,21 @@ export default function(input, {project, baseURI}) {
     // hashtags #tagname
         .replace(/(?!\B.*\/+\b)\B#(\b[\w+-\/]+\b)/g, function(fullTag, tagName) {
             if (owner && name) {
-                return `<a href="${baseURI}/projects/${owner}/${name}/talk/search?query=${tagName}">${fullTag}</a>`;
+                return `[${fullTag}](${baseURI}/projects/${owner}/${name}/talk/search?query=${tagName}")`
             }
             else {
-                return `<a href="${baseURI}/talk/search?query=${tagName}">${fullTag}</a>`;
+                return `[${fullTag}](${baseURI}/talk/search?query=${tagName})`
             }
         })
 
     // subjects in a specific project : @owner-slug/project-slug^Ssubject_id
     // \b[\w-]+\b is hyphen boundary for slugs
-        .replace(/@(\b[\w-]+\b)\/(\b[\w-]+\b)\^S([0-9]+)/g, `<a href="${baseURI}/projects/$1/$2/talk/subjects/$3" title="$1/$2 - Subject $3">Subject $3</a>`)
+
+        .replace(/@(\b[\w-]+\b)\/(\b[\w-]+\b)\^S([0-9]+)/g, `[Subject $3](${baseURI}/projects/$1/$2/talk/subjects/$3)`)
 
         .replace(/\^S([0-9]+)/g, function(_, subjectID) {
             if (owner && name) {
-                return `<a href="${baseURI}/projects/${owner}/${name}/talk/subjects/${subjectID}" title="${owner}/${name} - Subject ${subjectID}" >Subject ${subjectID}</a>`;
+                return `[Subject ${subjectID}](${baseURI}/projects/${owner}/${name}/talk/subjects/${subjectID})`
             }
             else {
                 return subjectID;
@@ -36,9 +37,10 @@ export default function(input, {project, baseURI}) {
     // user mentions : @username
         .replace(/\B@(\b[\w-.]+\b)/g, function(_, username) {
           if(restrictedUserNames.indexOf(username) < 0) {
-            return `<a href="${baseURI}/users/${username}">@${username}</a>`;
+              return `[@${username}](${baseURI}/users/${username})`
+
           } else {
-            return '@' + username;
+              return '@' + username;
           }
         });
 

--- a/test/lib/default-transformer-test.js
+++ b/test/lib/default-transformer-test.js
@@ -7,23 +7,23 @@ chai.use(spies);
 let {expect, spy} = chai;
 
 describe('default-transformer', () => {
-    var project, baseURI;
+    let project, baseURI;
     beforeEach(() => {
         project = null;
         baseURI = null;
     });
 
-    it('replaces #hashtags with hashtag links', () => {
-        var tagLink = replaceSymbols('#test', {project, baseURI});
-        expect(tagLink).to.equal('<a href="/talk/search?query=test">#test</a>');
+    it('replaces #hashtags with markdown hashtag links', () => {
+        const tagLink = replaceSymbols('#test', {project, baseURI});
+        expect(tagLink).to.equal('[#test](/talk/search?query=test)');
     });
 
-    it('replaces #hashtags inside of html without conflicting with urls', () => {
-        let html = `<p>#good \n https://www.zooniverse.org/talk/17/1403?page=1&comment=3063</p>`;
-        let htmlTagLink = replaceSymbols(html, {project, baseURI});
+    it('works in a sentence with multiple tags & a URL', () => {
+        const sentence = `#test sentenc #tag and url: http://docs.panoptes.apiary.io/#reference/user/users-collection/list-all-users`
 
-        expect(htmlTagLink).to.equal(`<p><a href="/talk/search?query=good">#good</a> \n https://www.zooniverse.org/talk/17/1403?page=1&comment=3063</p>`);
-    });
+        const htmlSentence = replaceSymbols(sentence, {project, baseURI})
+        expect(htmlSentence).to.equal(`#test sentenc #tag and url: http://docs.panoptes.apiary.io/#reference/user/users-collection/list-all-users`)
+    })
 
     it('ignores links with hashes', () => {
         const url = "http://docs.panoptes.apiary.io/#reference/user/users-collection/list-all-users";
@@ -34,40 +34,47 @@ describe('default-transformer', () => {
 
     it('allows delimiters in hashtags', () => {
         ['#test-tag', '#test_tag', '#test.tag'].forEach((tag) => {
-            let parsedTag = replaceSymbols(tag, {project, baseURI})
-            expect(parsedTag).to.equal(`<a href="/talk/search?query=${tag.slice(1, tag.length)}">${tag}</a>`)
+            const parsedTag = replaceSymbols(tag, {project, baseURI})
+            expect(parsedTag).to.equal(`[${tag}](/talk/search?query=${tag.slice(1, tag.length)})`)
         })
     })
 
     it('replaces ^S<subject_id> mentions with subject links', () =>{
         project = { slug: "test/project" };
-        var subjectLink = replaceSymbols('^S123456', {project, baseURI});;
-        expect(subjectLink).to.equal('<a href="/projects/test/project/talk/subjects/123456" title="test/project - Subject 123456" >Subject 123456</a>');
+        const subjectLink = replaceSymbols('^S123456', {project, baseURI});;
+        expect(subjectLink).to.equal('[Subject 123456](/projects/test/project/talk/subjects/123456)');
     });
 
+    it('replaces project #hashtag mentions with project links', () =>{
+        project = { slug: "test/project" };
+        const subjectLink = replaceSymbols('#S123456', {project, baseURI});;
+        expect(subjectLink).to.equal('[#S123456](/projects/test/project/talk/search?query=S123456")');
+    });
+
+
     it('does not format subject Ids when not in a routed context', () =>{
-        var subjectLink = replaceSymbols('^S123456', {project, baseURI});
+        const subjectLink = replaceSymbols('^S123456', {project, baseURI});
         expect(subjectLink).to.equal("123456");
     });
 
     it('replaces @username mentions with user links', () => {
         const userLink = replaceSymbols('@testuser', {project, baseURI});
-        expect(userLink).to.equal('<a href="/users/testuser">@testuser</a>');
+        expect(userLink).to.equal('[@testuser](/users/testuser)');
     });
 
     it('replaces @user.name mentions with user links', () => {
         const userLink = replaceSymbols('@test.user', {project, baseURI});
-        expect(userLink).to.equal('<a href="/users/test.user">@test.user</a>');
+        expect(userLink).to.equal('[@test.user](/users/test.user)');
     });
 
     it('it ignores restricted usernames', () => {
-        const userLink = replaceSymbols('@admins @moderators @team @test.user @researchers @scientists', {project, baseURI});
-        expect(userLink).to.equal('@admins @moderators @team <a href="/users/test.user">@test.user</a> @researchers @scientists');
+        const userLink = replaceSymbols('@admins @moderators @team @researchers @scientists', {project, baseURI});
+        expect(userLink).to.equal('@admins @moderators @team @researchers @scientists');
     });
 
     it('replaces @ownerslug/project-slug^S<subject_id> mentions with links', () => {
-        var projectSubjectLink = replaceSymbols('@owner/project-d^S123456', {project, baseURI});
+        const projectSubjectLink = replaceSymbols('@owner/project-d^S123456', {project, baseURI});
 
-        expect(projectSubjectLink).to.equal('<a href="/projects/owner/project-d/talk/subjects/123456" title="owner/project-d - Subject 123456">Subject 123456</a>');
+        expect(projectSubjectLink).to.equal('[Subject 123456](/projects/owner/project-d/talk/subjects/123456)');
     });
 });


### PR DESCRIPTION
- This changes how symbols are generated so they are parsed before the
  markdown has been transformed to html. This makes it easier to parse
  without needing to dance around html tags
- Also fixes bug where non-inline tags are not parsed
- Should be a transparent change to users, but eliminating edge cases 
associated with parsing symbols within html tags 

@chrissnyder or @edpaget mind taking a look? I updated the tests accordingly and checked via symlink to PFE, so should be good, and I think simpler than before