### PR TITLE
Add rel=nofollow attr to external markdown links 

### DIFF
--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -3,16 +3,19 @@ import MarkdownIt from "markdown-it";
 import MarkdownItContainer from "markdown-it-container";
 import twemoji from 'twemoji';
 import replaceSymbols from '../lib/default-transformer';
+import relNofollow from  '../lib/links-rel-nofollow'
 
-const markdownIt = new MarkdownIt({linkify: true, breaks: true})
+const markdownIt = function () {
+    return new MarkdownIt({linkify: true, breaks: true})
           .use(require('markdown-it-emoji'))
           .use(require('markdown-it-sub'))
           .use(require('markdown-it-sup'))
           .use(require('markdown-it-footnote'))
           .use(require('markdown-it-imsize'))
-          .use(require('../lib/links-transform'))
+          .use(require('../lib/links-in-new-tabs'))
           .use(MarkdownItContainer, 'partners')
           .use(MarkdownItContainer, 'attribution');
+}
 
 export default class Markdown extends React.Component {
     get displayName() {
@@ -23,12 +26,20 @@ export default class Markdown extends React.Component {
         return twemoji.parse(input);
     }
 
+    renderer() {
+        if (this.props && this.props.relNofollow) {
+            return markdownIt().use(relNofollow)
+        } else {
+            return markdownIt()
+        }
+    }
+
     markdownify(input) {
         if (this.props && this.props.inline) {
-            return markdownIt.renderInline(input);
+            return this.renderer().renderInline(input);
         }
         else {
-            return markdownIt.render(input);
+            return this.renderer().render(input);
         }
     }
 
@@ -64,5 +75,6 @@ Markdown.defaultProps = {
     transform: replaceSymbols,
     project: null,
     baseURI: null,
-    className: ''
+    className: '',
+    relNofollow: false
 }

--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -10,7 +10,7 @@ const markdownIt = new MarkdownIt({linkify: true, breaks: true})
           .use(require('markdown-it-sup'))
           .use(require('markdown-it-footnote'))
           .use(require('markdown-it-imsize'))
-          .use(require('../lib/links-in-new-tabs'))
+          .use(require('../lib/links-transform'))
           .use(MarkdownItContainer, 'partners')
           .use(MarkdownItContainer, 'attribution');
 

--- a/src/lib/links-in-new-tabs.js
+++ b/src/lib/links-in-new-tabs.js
@@ -1,0 +1,28 @@
+export default function(md, opts) {
+    // Remember old renderer, if overridden, or proxy to default renderer
+    const defaultRender = md.renderer.rules.link_open || function(tokens, idx, options, env, self) {
+        return self.renderToken(tokens, idx, options);
+    };
+
+    const prefix = (opts && opts.prefix) ? opts.prefix : '+tab+';
+
+    md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+        const hrefIndex = tokens[idx].attrIndex('href');
+        const href = tokens[idx].attrs[hrefIndex][1];
+
+        if (prefix === href.slice(0, prefix.length)) {
+            // trim prefix if href starts with prefix
+            tokens[idx].attrs[hrefIndex][1] = href.slice(prefix.length, href.length);
+            const aIndex = tokens[idx].attrIndex('target');
+
+            if (aIndex < 0) {
+                tokens[idx].attrPush(['target', '_blank']); // add new attribute
+            } else {
+                tokens[idx].attrs[aIndex][1] = '_blank';    // replace value of existing attr
+            }
+        }
+
+        // pass token to default renderer
+        return defaultRender(tokens, idx, options, env, self);
+    };
+}

--- a/src/lib/links-in-new-tabs.js
+++ b/src/lib/links-in-new-tabs.js
@@ -7,25 +7,36 @@
 
 export default function(md, opts) {
     // Remember old renderer, if overridden, or proxy to default renderer
-    var defaultRender = md.renderer.rules.link_open || function(tokens, idx, options, env, self) {
+    const defaultRender = md.renderer.rules.link_open || function(tokens, idx, options, env, self) {
         return self.renderToken(tokens, idx, options);
     };
 
     const prefix = (opts && opts.prefix) ? opts.prefix : '+tab+';
 
     md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
-        var hrefIndex = tokens[idx].attrIndex('href');
-        var href = tokens[idx].attrs[hrefIndex][1];
+        const hrefIndex = tokens[idx].attrIndex('href');
+        const href = tokens[idx].attrs[hrefIndex][1];
 
         if (prefix === href.slice(0, prefix.length)) {
             // trim prefix if href starts with prefix
             tokens[idx].attrs[hrefIndex][1] = href.slice(prefix.length, href.length);
-            var aIndex = tokens[idx].attrIndex('target');
+            const aIndex = tokens[idx].attrIndex('target');
 
             if (aIndex < 0) {
                 tokens[idx].attrPush(['target', '_blank']); // add new attribute
             } else {
                 tokens[idx].attrs[aIndex][1] = '_blank';    // replace value of existing attr
+            }
+        }
+
+        const relIndex = tokens[idx].attrIndex('rel');
+
+        if (!href.match(/zooniverse.org/)) {
+            // add rel=nofollow to external links
+            if (relIndex < 0) {
+                tokens[idx].attrPush(['rel', 'nofollow'])
+            } else {
+                tokens[idx].attrs[relIndex][1] = 'nofollow';
             }
         }
 

--- a/src/lib/links-rel-nofollow.js
+++ b/src/lib/links-rel-nofollow.js
@@ -1,11 +1,3 @@
-/* 
- links-transform.js
- opens links in a new tab if prefixed with +tab+
- adds rel=nofollow if not a zooniverse.org link
- accepts options of {prefix: 'your-custom-prefix'}
- 'prefix' is the string to use before links for links to open in new tab
- */ 
-
 export default function(md, opts) {
     // Remember old renderer, if overridden, or proxy to default renderer
     const defaultRender = md.renderer.rules.link_open || function(tokens, idx, options, env, self) {
@@ -17,19 +9,6 @@ export default function(md, opts) {
     md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
         const hrefIndex = tokens[idx].attrIndex('href');
         const href = tokens[idx].attrs[hrefIndex][1];
-
-        if (prefix === href.slice(0, prefix.length)) {
-            // trim prefix if href starts with prefix
-            tokens[idx].attrs[hrefIndex][1] = href.slice(prefix.length, href.length);
-            const aIndex = tokens[idx].attrIndex('target');
-
-            if (aIndex < 0) {
-                tokens[idx].attrPush(['target', '_blank']); // add new attribute
-            } else {
-                tokens[idx].attrs[aIndex][1] = '_blank';    // replace value of existing attr
-            }
-        }
-
         const relIndex = tokens[idx].attrIndex('rel');
 
         if (!href.match(/zooniverse.org/)) {

--- a/src/lib/links-transform.js
+++ b/src/lib/links-transform.js
@@ -1,6 +1,7 @@
 /* 
- markdown-it-links-in-new-tabs.js
+ links-transform.js
  opens links in a new tab if prefixed with +tab+
+ adds rel=nofollow if not a zooniverse.org link
  accepts options of {prefix: 'your-custom-prefix'}
  'prefix' is the string to use before links for links to open in new tab
  */ 

--- a/test/components/markdown-test.js
+++ b/test/components/markdown-test.js
@@ -40,7 +40,7 @@ describe('Markdown', () => {
 
         it('opens links in a new tab when prefixed by +tab+', () => {
             var md = markdown.markdownify('[A link](+tab+http://www.google.com)');
-            expect(md).to.equal('<p><a href="http://www.google.com" target="_blank">A link</a></p>\n')
+            expect(md).to.equal('<p><a href="http://www.google.com" target="_blank" rel="nofollow">A link</a></p>\n')
         });
     });
 

--- a/test/components/markdown-test.js
+++ b/test/components/markdown-test.js
@@ -12,7 +12,7 @@ describe('Markdown', () => {
     var markdown;
 
     beforeEach(() => {
-        markdown = new Markdown();
+        markdown = addons.TestUtils.renderIntoDocument(<Markdown />)
     });
 
     it('exists', () => {
@@ -27,6 +27,7 @@ describe('Markdown', () => {
             inline: false,
             baseURI: null,
             project: null,
+            relNofollow: false,
             transform: Markdown.defaultProps.transform,
             className: ''
         });
@@ -40,7 +41,7 @@ describe('Markdown', () => {
 
         it('opens links in a new tab when prefixed by +tab+', () => {
             var md = markdown.markdownify('[A link](+tab+http://www.google.com)');
-            expect(md).to.equal('<p><a href="http://www.google.com" target="_blank" rel="nofollow">A link</a></p>\n')
+            expect(md).to.equal('<p><a href="http://www.google.com" target="_blank">A link</a></p>\n')
         });
     });
 
@@ -60,6 +61,21 @@ describe('Markdown', () => {
             expect(html).to.equal('Test text');
         });
     });
+
+    describe('#renderer', () => {
+        it('uses relNofollow when passed as a prop', () => {
+            var md = TestUtils.renderIntoDocument(React.createElement(Markdown, { className: 'MyComponent', relNofollow: true}, '[Test](link)'));
+
+            expect(md.getHtml()).to.equal('<p><a href="link" rel="nofollow">Test</a></p>\n')
+        })
+
+        it('doesn\'t use relNofollow when not passed as a prop', () => {
+            var md = TestUtils.renderIntoDocument(React.createElement(Markdown, { className: 'MyComponent', relNofollow: false}, '[Test](link)'));
+
+            expect(md.getHtml()).to.equal('<p><a href="link">Test</a></p>\n')
+        })
+
+    })
 
     describe('#render', () => {
         var editor, md;

--- a/test/lib/links-in-new-tabs-test.js
+++ b/test/lib/links-in-new-tabs-test.js
@@ -1,16 +1,16 @@
-import linksInNewTabs from '../../src/lib/links-in-new-tabs';
+import linksTransform from '../../src/lib/links-transform';
 import MarkdownIt from 'markdown-it'
 import chai from 'chai';
 import spies from 'chai-spies';
 chai.use(spies);
 let {expect, spy} = chai;
 
-describe('links-in-new-tabs', () => {
+describe('links-transform', () => {
     var mdIt;
 
     beforeEach(() => {
         mdIt = new MarkdownIt({linkify: true, breaks: true})
-            .use(linksInNewTabs)
+            .use(linksTransform)
     });
 
     it('opens links prefixed with +tab+ in a _blank target by default', () => {
@@ -25,7 +25,7 @@ describe('links-in-new-tabs', () => {
 
     it('accepts a customizable prefix', () => {
         mdIt = new MarkdownIt({linkify: true, breaks: true})
-            .use(linksInNewTabs, {prefix: '=newtab='})
+            .use(linksTransform, {prefix: '=newtab='})
 
         const md = mdIt.renderInline('[Test](=newtab=http://www.example.com)');
         expect(md).to.equal('<a href="http://www.example.com" target="_blank" rel="nofollow">Test</a>');

--- a/test/lib/links-in-new-tabs-test.js
+++ b/test/lib/links-in-new-tabs-test.js
@@ -15,12 +15,12 @@ describe('links-in-new-tabs', () => {
 
     it('opens links prefixed with +tab+ in a _blank target by default', () => {
         const md = mdIt.renderInline('[Test](+tab+http://www.example.com)');
-        expect(md).to.equal('<a href="http://www.example.com" target="_blank">Test</a>');
+        expect(md).to.equal('<a href="http://www.example.com" target="_blank" rel="nofollow">Test</a>');
     });
 
     it('renders normal links without a new tab prefix', () => {
         const md = mdIt.renderInline('[Test](http://www.example.com)');
-        expect(md).to.equal('<a href="http://www.example.com">Test</a>');
+        expect(md).to.equal('<a href="http://www.example.com" rel="nofollow">Test</a>');
     });
 
     it('accepts a customizable prefix', () => {
@@ -28,7 +28,14 @@ describe('links-in-new-tabs', () => {
             .use(linksInNewTabs, {prefix: '=newtab='})
 
         const md = mdIt.renderInline('[Test](=newtab=http://www.example.com)');
-        expect(md).to.equal('<a href="http://www.example.com" target="_blank">Test</a>');
+        expect(md).to.equal('<a href="http://www.example.com" target="_blank" rel="nofollow">Test</a>');
     });
-});
 
+    it('does not add a rel=nofollow attr to zooniverse.org links', () => {
+        const md = mdIt.renderInline('[Talk Link](http://www.zooniverse.org/talk)');
+
+        expect(md).to.equal('<a href="http://www.zooniverse.org/talk">Talk Link</a>');
+        
+    })
+
+});

--- a/test/lib/links-in-new-tabs-test.js
+++ b/test/lib/links-in-new-tabs-test.js
@@ -1,11 +1,11 @@
-import linksTransform from '../../src/lib/links-transform';
+import linksTransform from '../../src/lib/links-in-new-tabs';
 import MarkdownIt from 'markdown-it'
 import chai from 'chai';
 import spies from 'chai-spies';
 chai.use(spies);
 let {expect, spy} = chai;
 
-describe('links-transform', () => {
+describe('links-in-new-tabs', () => {
     var mdIt;
 
     beforeEach(() => {
@@ -15,12 +15,12 @@ describe('links-transform', () => {
 
     it('opens links prefixed with +tab+ in a _blank target by default', () => {
         const md = mdIt.renderInline('[Test](+tab+http://www.example.com)');
-        expect(md).to.equal('<a href="http://www.example.com" target="_blank" rel="nofollow">Test</a>');
+        expect(md).to.equal('<a href="http://www.example.com" target="_blank">Test</a>');
     });
 
     it('renders normal links without a new tab prefix', () => {
         const md = mdIt.renderInline('[Test](http://www.example.com)');
-        expect(md).to.equal('<a href="http://www.example.com" rel="nofollow">Test</a>');
+        expect(md).to.equal('<a href="http://www.example.com">Test</a>');
     });
 
     it('accepts a customizable prefix', () => {
@@ -28,14 +28,7 @@ describe('links-transform', () => {
             .use(linksTransform, {prefix: '=newtab='})
 
         const md = mdIt.renderInline('[Test](=newtab=http://www.example.com)');
-        expect(md).to.equal('<a href="http://www.example.com" target="_blank" rel="nofollow">Test</a>');
+        expect(md).to.equal('<a href="http://www.example.com" target="_blank">Test</a>');
     });
-
-    it('does not add a rel=nofollow attr to zooniverse.org links', () => {
-        const md = mdIt.renderInline('[Talk Link](http://www.zooniverse.org/talk)');
-
-        expect(md).to.equal('<a href="http://www.zooniverse.org/talk">Talk Link</a>');
-        
-    })
 
 });

--- a/test/lib/links-rel-nofollow.js
+++ b/test/lib/links-rel-nofollow.js
@@ -1,0 +1,26 @@
+import relNofollow from '../../src/lib/links-rel-nofollow';
+import MarkdownIt from 'markdown-it'
+import chai from 'chai';
+import spies from 'chai-spies';
+chai.use(spies);
+let {expect, spy} = chai;
+
+describe('links-rel-nofollow', () => {
+    var mdIt;
+
+    beforeEach(() => {
+        mdIt = new MarkdownIt({linkify: true, breaks: true})
+            .use(relNofollow)
+    });
+
+    it('adds rel=nofollow to links', () => {
+        const md = mdIt.renderInline('[Example Link](http://www.example.org)')
+        expect(md).to.equal('<a href="http://www.example.org" rel="nofollow">Example Link</a>');
+    })
+
+    it('does not add a rel=nofollow attr to zooniverse.org links', () => {
+        const md = mdIt.renderInline('[Talk Link](http://www.zooniverse.org/talk)');
+
+        expect(md).to.equal('<a href="http://www.zooniverse.org/talk">Talk Link</a>');
+    })
+});


### PR DESCRIPTION
- Adds rel=nofollow attr to non zooniverse.org links
  - Available via an optional `relNofollow` prop to `Markdown`
- Replaces a few vars with consts - no particular reason here, just since they're never changed
- Closes #22

