### PR TITLE
Update to React 0.14.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,13 +34,14 @@
     "gulp-mocha": "^2.1.3",
     "mocha": "^2.2.5",
     "node-jsdom": "^3.1.5",
-    "react": "^0.13.3",
+    "react": "^0.14.1",
+    "react-addons-test-utils": "^0.14.1",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.3.1",
     "zuul": "^3.2.0"
   },
   "peerDependencies": {
-    "react": "^0.13.3",
+    "react": "^0.14.x",
     "babelify": "^6.1.3"
   },
   "dependencies": {

--- a/src/components/markdown-editor.jsx
+++ b/src/components/markdown-editor.jsx
@@ -125,7 +125,7 @@ export default class MarkdownEditor extends React.Component {
                 value = e.target.value;
             }
             else {
-                value = this.refs.textarea.getDOMNode().value;
+                value = this.refs.textarea.value;
             }
             var event = {
                 target: {
@@ -151,7 +151,7 @@ export default class MarkdownEditor extends React.Component {
         // helper to call markdown-insert functions on the textarea
         // wrapFn takes / returns a string (from ./lib/markdown-insert.cjsx)
 
-        var textarea = this.refs.textarea.getDOMNode(),
+        var textarea = this.refs.textarea,
             selection = m.getSelection(textarea),
             text,cursor;
 
@@ -162,7 +162,7 @@ export default class MarkdownEditor extends React.Component {
     }
 
     wrapLinesIn(wrapFn, opts = {}) {
-        var textarea = this.refs.textarea.getDOMNode();
+        var textarea = this.refs.textarea;
         var lines = m.getSelection(textarea).split("\n");
 
         var formattedText = lines

--- a/test/components/markdown-editor-test.js
+++ b/test/components/markdown-editor-test.js
@@ -1,7 +1,8 @@
 import dom from '../test-setup';
 
 import MarkdownEditor from '../../src/components/markdown-editor.jsx';
-import React, {addons} from 'react';
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
 
 import chai from 'chai';
 import spies from 'chai-spies';
@@ -9,18 +10,14 @@ chai.use(spies);
 let {expect, spy} = chai;
 
 let mockTextarea = function() {
-    return {
-        textarea: {
-            getDOMNode: () => {
-                return {
-                    focus: () => {},
-                    value: "A long\nboring string that doesn't mean anything",
-                    selectionStart: 2,
-                    selectionEnd: 10
-                };
-            }
-        }
-    };
+  return {
+    textarea: {
+      focus: () => {},
+      value: "A long\nboring string that doesn't mean anything",
+      selectionStart: 2,
+      selectionEnd: 10
+    }
+  };
 };
 
 describe('MarkdownEditor', () => {
@@ -103,7 +100,7 @@ describe('MarkdownEditor', () => {
 
     describe("#handlePreviewToggle", () => {
         it("should toggle the preview State", () => {
-            editor = addons.TestUtils.renderIntoDocument(<MarkdownEditor value="##blah blash" />);
+            editor = TestUtils.renderIntoDocument(<MarkdownEditor value="##blah blash" />);
             editor.handlePreviewToggle();
             expect(editor.state.previewing).to.be.true;
         });
@@ -111,7 +108,7 @@ describe('MarkdownEditor', () => {
 
     describe("#componentWillMount", () => {
         it("should set state.previewing to the value of the previewing prop", () => {
-            editor = addons.TestUtils.renderIntoDocument(<MarkdownEditor previewing={true} value="##blah blash" />);
+            editor = TestUtils.renderIntoDocument(<MarkdownEditor previewing={true} value="##blah blash" />);
             expect(editor.state.previewing).to.be.true;
         });
     });
@@ -130,66 +127,66 @@ describe('MarkdownEditor', () => {
              it(`should setup a click listener for ${name} button`, () => {
                  cbName = cbName || name.charAt(0).toUpperCase() + name.slice(1);
                  var cbSpy = spy.on(MarkdownEditor.prototype, `on${cbName}Click`);
-                 editor = addons.TestUtils.renderIntoDocument(<MarkdownEditor value="##blah blash" />);
-                 editor.refs = mockTextarea();
-                 var button = addons.TestUtils.findRenderedDOMComponentWithClass(editor, `talk-comment-${name}-button`);
-                 addons.TestUtils.Simulate.click(button);
+                 editor = TestUtils.renderIntoDocument(<MarkdownEditor value="##blah blash" />);
+                 var button = TestUtils.findRenderedDOMComponentWithClass(editor, `talk-comment-${name}-button`);
+                 TestUtils.Simulate.click(button);
                  expect(cbSpy).to.have.been.called();
              });
          });
 
         context("when previewing is true", () => {
             beforeEach(() => {
-                editor = addons.TestUtils.renderIntoDocument(<MarkdownEditor previewing={true} />);
+                editor = TestUtils.renderIntoDocument(<MarkdownEditor previewing={true} />);
             });
 
             it("should set the preview icon to pencil", () => {
-                var icon = addons.TestUtils.findRenderedDOMComponentWithClass(editor, 'fa-pencil');
+                var icon = TestUtils.findRenderedDOMComponentWithClass(editor, 'fa-pencil');
                 expect(icon).to.be.ok;
             });
 
             it("should set data-previewing to true", () => {
-                var md = addons.TestUtils.findRenderedDOMComponentWithClass(editor, 'markdown-editor');
-                expect(md.props['data-previewing']).to.be.true;
+                var md = TestUtils.findRenderedDOMComponentWithClass(editor, 'markdown-editor');
+                expect(md.hasAttribute('data-previewing')).to.be.true;
             });
         });
 
         context("when previewing is false", () => {
             beforeEach(() => {
-                editor = addons.TestUtils.renderIntoDocument(<MarkdownEditor previewing={false} />);
+                editor = TestUtils.renderIntoDocument(<MarkdownEditor previewing={false} />);
             });
 
             it("should set the preview icon to eye", () => {
-                var icon = addons.TestUtils.findRenderedDOMComponentWithClass(editor, 'fa-eye');
+                var icon = TestUtils.findRenderedDOMComponentWithClass(editor, 'fa-eye');
                 expect(icon).to.be.ok;
             });
 
             it("should not set data-previewing", () => {
-                var md = addons.TestUtils.findRenderedDOMComponentWithClass(editor, 'markdown-editor');
-                expect(md.props['data-previewing']).to.be.null;
+                var md = TestUtils.findRenderedDOMComponentWithClass(editor, 'markdown-editor');
+                expect(md.hasAttribute('data-previewing')).to.be.false;
             });
         });
 
         it("should render a markdown preview from the value property", () => {
-            editor = addons.TestUtils.renderIntoDocument(<MarkdownEditor value="## blah blah"/>);
-            let markdown = addons.TestUtils.findRenderedDOMComponentWithClass(editor, "markdown-editor-preview")
-            expect(markdown.props.dangerouslySetInnerHTML.__html).to.match(/blah blah/);
+            editor = TestUtils.renderIntoDocument(<MarkdownEditor value="## blah blah"/>);
+            let markdown = TestUtils.findRenderedDOMComponentWithClass(editor, "markdown-editor-preview")
+            expect(markdown.innerHTML).to.match(/blah blah/);
         });
 
         it("should pass properties to the textarea", () => {
             var properties = {
-                rows: 5,
-                cols: 10,
+                rows: '5',
+                cols: '10',
                 placeholder: "asdfasdf",
-                name: "hey there",
-                value: "oh there"
+                name: "hey there"
             };
-            editor = addons.TestUtils.renderIntoDocument(<MarkdownEditor {...properties}/>);
-            var textarea = addons.TestUtils.findRenderedDOMComponentWithTag(editor, 'textarea');
+            var value = "oh there";
+            editor = TestUtils.renderIntoDocument(<MarkdownEditor {...properties} value={value}/>);
+            var textarea = TestUtils.findRenderedDOMComponentWithTag(editor, 'textarea');
             Object.keys(properties).forEach((key) => {
-                let value = properties[key];
-                expect(textarea.props).to.have.property(key).that.equals(value);
+              let value = properties[key];
+              expect(textarea.getAttribute(key)).to.be.equal(value);
             });
+            expect(textarea.value).to.equal(value);
         });
     });
 });

--- a/test/components/markdown-test.js
+++ b/test/components/markdown-test.js
@@ -1,7 +1,7 @@
 import dom from "../test-setup";
 import Markdown from "../../src/components/markdown.jsx";
-import React, {addons} from 'react/addons';
-const TestUtils = addons.TestUtils;
+import React from 'react'
+import TestUtils from 'react-addons-test-utils';
 
 import chai from 'chai';
 import spies from 'chai-spies';
@@ -12,7 +12,7 @@ describe('Markdown', () => {
     var markdown;
 
     beforeEach(() => {
-        markdown = addons.TestUtils.renderIntoDocument(<Markdown />)
+        markdown = TestUtils.renderIntoDocument(<Markdown />)
     });
 
     it('exists', () => {
@@ -45,18 +45,20 @@ describe('Markdown', () => {
         });
     });
 
-    describe('#getHtml', () =>{
-        var md = TestUtils.renderIntoDocument(React.createElement(Markdown, { className: 'MyComponent'}, 'Test text'));
+    describe('#getHtml', () => {
+        let errorTransform = () => {
+          throw new Error('fail')
+        }
 
         it('returns the formatted html', () => {
+            let md = TestUtils.renderIntoDocument(React.createElement(Markdown, { className: 'MyComponent' }, 'Test text'));
+
             let html = md.getHtml();
             expect(html).to.equal('<p>Test text</p>\n');
         });
 
         it('renders bare child content on error', () => {
-            md.props.transform = () => {
-                throw new Error("fail");
-            };
+            let md = TestUtils.renderIntoDocument(React.createElement(Markdown, { className: 'MyComponent', transform: errorTransform }, 'Test text'));
             let html = md.getHtml();
             expect(html).to.equal('Test text');
         });
@@ -92,7 +94,7 @@ describe('Markdown', () => {
 
         it('renders', () => {
             var markdownDiv = TestUtils.findRenderedDOMComponentWithTag(md, 'div');
-            expect(markdownDiv.props.dangerouslySetInnerHTML.__html).to.equal('<p>Test children bar</p>\n');
+            expect(markdownDiv.innerHTML).to.equal('<p>Test children bar</p>\n');
         });
 
         it('calls getHtml in render', () => {


### PR DESCRIPTION
Not as bad a diff as I'd thought it'd be. Changes almost all dealing with the fact that `this.refs.someRef` directly returns the DOM node.

Only weird part is at https://github.com/zooniverse-ui/markdownz/compare/upgrade-react?expand=1#diff-21a803523cfe396d251006c217b95ab7R187. Apparently textarea.getAttribute('value') returns it's children, not the value attribute. And I couldn't do just textarea[key] because textarea.placeholder is undefined. Open to ideas here.