### PR TITLE
Honour preview prop lifecycle

### DIFF
--- a/src/components/markdown-editor.jsx
+++ b/src/components/markdown-editor.jsx
@@ -54,6 +54,15 @@ export default class MarkdownEditor extends React.Component {
         this.setState({previewing: !!this.props.previewing});
     }
 
+    componentWillReceiveProps(nextProps) {
+        // If previewing prop has changed, update internal state
+        if (typeof nextProps.previewing === 'boolean') {
+            this.setState({
+                previewing: nextProps.previewing
+            });
+        }
+    }
+
     render() {
         var previewIcon;
         if (this.state.previewing) {

--- a/test/components/markdown-editor-test.js
+++ b/test/components/markdown-editor-test.js
@@ -113,6 +113,28 @@ describe('MarkdownEditor', () => {
         });
     });
 
+    describe("#componentWillReceiveProps", () => {
+        it("should set state.previewing to the value of the previewing prop (after mount)", () => {
+            // We can't manipulate props of editor directly, so create a parent component to do it via render
+            var TestParent = React.createFactory(React.createClass({
+              getInitialState() {
+                return {
+                  previewing: true
+                };
+              },
+              render() {
+                return <MarkdownEditor ref="editor" previewing={this.state.previewing} value="##blah blash"  />
+              }
+            }));
+
+            var parent = TestUtils.renderIntoDocument(TestParent());
+            parent.setState({
+              previewing: false
+            });
+            expect(parent.refs.editor.state.previewing).to.be.false;
+        });
+    });
+
     describe("#render", () => {
         [["insert-link", "InsertLink"],
          ["insert-image", "InsertImage"],


### PR DESCRIPTION
Allows other components to toggle the previewing state of `<MarkdownEditor />`. (Currently the `previewing` prop is only honoured at mount time - updates do not propagate to state).

This is towards [zooniverse/Panoptes-Front-End#1972](https://github.com/zooniverse/Panoptes-Front-End/issues/1972).

