### PR TITLE
Fix hashtag links to correctly go to the hashtag results, and not...

### DIFF
--- a/src/lib/default-transformer.js
+++ b/src/lib/default-transformer.js
@@ -13,7 +13,7 @@ export default function(input, {project, baseURI}) {
     // hashtags #tagname
         .replace(/(?!\B.*\/+\b)\B#(\b[\w+-\/]+\b)/g, function(fullTag, tagName) {
             if (owner && name) {
-                return `[${fullTag}](${baseURI}/projects/${owner}/${name}/talk/search?query=${tagName})`
+                return `[${fullTag}](${baseURI}/projects/${owner}/${name}/talk/tags/${tagName})`
             }
             else {
                 return `[${fullTag}](${baseURI}/talk/search?query=${tagName})`

--- a/test/lib/default-transformer-test.js
+++ b/test/lib/default-transformer-test.js
@@ -48,7 +48,7 @@ describe('default-transformer', () => {
     it('replaces project #hashtag mentions with project links', () =>{
         project = { slug: "test/project" };
         const subjectLink = replaceSymbols('#S123456', {project, baseURI});;
-        expect(subjectLink).to.equal('[#S123456](/projects/test/project/talk/search?query=S123456)');
+        expect(subjectLink).to.equal('[#S123456](/projects/test/project/talk/tags/S123456)');
     });
 
 


### PR DESCRIPTION
 ...include occurrences of the word with no hash. 
This fixes https://github.com/zooniverse/Panoptes-Front-End/issues/2104 and https://github.com/zooniverse/Panoptes-Front-End/issues/2065 (but not https://github.com/zooniverse/Panoptes-Front-End/issues/2066)