### PR TITLE
import statements instead of requires

### DIFF
--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -5,16 +5,23 @@ import twemoji from 'twemoji';
 import replaceSymbols from '../lib/default-transformer';
 import relNofollow from  '../lib/links-rel-nofollow'
 
+import markdownEmoji from 'markdown-it-emoji';
+import markdownSub from 'markdown-it-sub';
+import markdownSup from 'markdown-it-sup';
+import markdownFootnote from 'markdown-it-footnote';
+import markdownImsize from 'markdown-it-imsize';
+import markdownNewTab from '../lib/links-in-new-tabs';
+
 const markdownIt = function () {
     return new MarkdownIt({linkify: true, breaks: true})
-          .use(require('markdown-it-emoji'))
-          .use(require('markdown-it-sub'))
-          .use(require('markdown-it-sup'))
-          .use(require('markdown-it-footnote'))
-          .use(require('markdown-it-imsize'))
-          .use(require('../lib/links-in-new-tabs'))
-          .use(MarkdownItContainer, 'partners')
-          .use(MarkdownItContainer, 'attribution');
+                .use(markdownEmoji)
+                .use(markdownSub)
+                .use(markdownSup)
+                .use(markdownFootnote)
+                .use(markdownImsize)
+                .use(markdownNewTab)
+                .use(MarkdownItContainer, 'partners')
+                .use(MarkdownItContainer, 'attribution');
 }
 
 export default class Markdown extends React.Component {


### PR DESCRIPTION
When we consume markdownz using webpack, none of the require statements that I removed work correctly, resulting in the markdown not being rendered into HTML.

This change simply uses the import syntax and then passes the imported plugin objects instead of requiring them on the fly.

This will require a version bump/republish on the markdownz package, unfortunately.